### PR TITLE
add Send and Sync impls for ComPtr and ComRef

### DIFF
--- a/com-scrape-types/src/ptr.rs
+++ b/com-scrape-types/src/ptr.rs
@@ -69,6 +69,10 @@ impl<'a, I: Interface> Clone for ComRef<'a, I> {
     }
 }
 
+unsafe impl<'a, I: Interface> Send for ComRef<'a, I> where I: Sync + Send {}
+
+unsafe impl<'a, I: Interface> Sync for ComRef<'a, I> where I: Sync + Send {}
+
 impl<'a, I: Interface> ComRef<'a, I> {
     /// Gets the wrapped interface pointer.
     ///
@@ -191,6 +195,10 @@ impl<I: Interface> Clone for ComPtr<I> {
         ComPtr { ptr: self.ptr }
     }
 }
+
+unsafe impl<I: Interface> Send for ComPtr<I> where I: Sync + Send {}
+
+unsafe impl<I: Interface> Sync for ComPtr<I> where I: Sync + Send {}
 
 impl<I: Interface> Drop for ComPtr<I> {
     #[inline]


### PR DESCRIPTION
ComPtr<T> and ComRef<T> currently do not implement Send or Sync, regardless of what T is, since they contain NonNull fields. This is unnecessarily restrictive. Add Send and Sync impls for ComPtr and ComRef with the same bounds as the Send and Sync impls for Arc in the standard library.